### PR TITLE
[S3Fuse] Mount the directory specifying the UID and GID

### DIFF
--- a/emr_notebooks_magics/mount_workspace_dir.py
+++ b/emr_notebooks_magics/mount_workspace_dir.py
@@ -144,6 +144,13 @@ class MountWorkspaceDirMagics(Magics):
         if read_only and "umask" not in mount_params:
             mount_params = "-o umask=277 " + mount_params
 
+        # mount the directory as the current user
+        if "uid" not in mount_params:
+            mount_params = "-o uid={} ".format(os.getuid()) + mount_params
+
+        if "gid" not in mount_params:
+            mount_params = "-o gid={} ".format(os.getgid()) + mount_params
+
         command = "s3fs {}{}:/{} {}".format(mount_params, s3_bucket, s3_key, mount_dir)
         print("Executing command ", command)
         return self._execute_command(command)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 setup(
     name="emr-notebooks-magics",
-    version="0.1",
+    version="0.2.0",
     description="Jupyter Magics for EMR Notebooks.",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
*Description of changes:*
Mount the directory specifying the UID/GID of the current user. 

*Issue*
S3fs uses the UID/GID from the s3 object metadata and this will make the files inaccessible to the current user if the UID/GID of the current user doesnt match with UID/GID from s3 metadata.

*Fix*
Use current user's UID/GID (user executing the code) to mount the directory

*Testing*

*Reproduce the issue*
On a different S3 mount, created files with UID/GID 1000/1000.

Mounted workspace using `mount_workspace_dir` magic and noticed that current files are inaccessible with owner as `ec2-user` (1000/1000 belongs to ec2-user on master node)

```
$ ls -la

total 4
dr-x------ 1 emr-notebook emr-notebook    0 Jan  1  1970 ./
drwxr-xr-x 6 emr-notebook emr-notebook  143 Dec  6 17:17 ../
dr-x------ 1 ec2-user     users           0 Dec  6 17:04 .ipynb_checkpoints/
-r-x------ 1 ec2-user     users        1955 Dec  6 17:14 Untitled.ipynb*
```

The files are inaccessible as they belong to different user.
```
$ cat Untitled.ipynb

cat: Untitled.ipynb: Permission denied
```

*Test the fix*
Upgrade the emr-notebook-magic with the changes from this PR.

```
sudo /mnt/notebook-env/bin/pip install --extra-index-url https://test.pypi.org/simple/ emr-notebooks-magics==0.2.0
```

Verify the version

```
$ /mnt/notebook-env/bin/pip freeze | grep emr-notebook

emr-notebooks-magics==0.2.0

```

Mount the workspace
```
%mount_workspace_dir .

Executing command  s3fs -o gid=1002 -o uid=1001 -o umask=277 -o iam_role=auto aws-emr-resources-531950694711-eu-west-1:/notebooks/e-32I2UL1DXUHC0YJG1K2FEXUG7/ /home/emr-notebook/e-32I2UL1DXUHC0YJG1K2FEXUG7
Successfully mounted EMR Workspace on the cluster
```

List the files and observed that files belong to the emr-notebook user.
```
$ ls -la

total 27
dr-x------ 1 emr-notebook emr-notebook     0 Jan  1  1970 ./
drwxr-xr-x 7 emr-notebook emr-notebook   157 Dec  6 18:20 ../
dr-x------ 1 emr-notebook emr-notebook     0 Dec  6 17:04 .ipynb_checkpoints/
-r-x------ 1 emr-notebook emr-notebook 25850 Dec  6 18:23 Untitled.ipynb*
-r-x------ 1 emr-notebook emr-notebook    72 Dec  6 17:04 npalania-fuse-test.ipynb*
```

Access the file

```
$ cat Untitled.ipynb

{
 "cells": [
.....
```

Verified that mount with `Goofys` is not impacted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
