### PR TITLE
Enable compat_dir option by default for s3fs-fuse mount

### DIFF
--- a/emr_notebooks_magics/mount_workspace_dir.py
+++ b/emr_notebooks_magics/mount_workspace_dir.py
@@ -143,6 +143,8 @@ class MountWorkspaceDirMagics(Magics):
         # readonly mount by default
         if read_only and "umask" not in mount_params:
             mount_params = "-o umask=277 " + mount_params
+        if "notsup_compat_dir" not in mount_params:
+            mount_params = "-o compat_dir " + mount_params
 
         # mount the directory as the current user
         if "uid" not in mount_params:


### PR DESCRIPTION

*Description of changes:*
Recent commit to S3fs [pull 1970](https://github.com/s3fs-fuse/s3fs-fuse/pull/1970/files) disables `compat_dir` by default and this breaks `%mount_workspace_dir` magic which mounts the EMR Studio Workspace. This is because the EMR Studio uses old s3 path style and the path `<workspace_location_s3_prefix>/<workspace_id>/` is not defined as explicitly as directory using content type   `application/x-directory`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
